### PR TITLE
add error reporting to read functions

### DIFF
--- a/MechaQMC5883.h
+++ b/MechaQMC5883.h
@@ -40,11 +40,11 @@ void setMode(uint16_t mode,uint16_t odr,uint16_t rng,uint16_t osr); // setting
 
 void softReset(); //soft RESET
 
-void read(uint16_t* x,uint16_t* y,uint16_t* z); //reading
-void read(uint16_t* x,uint16_t* y,uint16_t* z,int* a);
-void read(uint16_t* x,uint16_t* y,uint16_t* z,float* a);
+int read(int* x,int* y,int* z); //reading
+int read(int* x,int* y,int* z,int* a);
+int read(int* x,int* y,int* z,float* a);
 
-float azimuth(uint16_t* a,uint16_t* b);
+float azimuth(int* a,int* b);
 
 private:
 


### PR DESCRIPTION
read function returns status of both the i2c transmission and the internal qmc magnetic overflow state.

Also change to int instead of specific int16_t, as that works better on 32bit (eg esp8266).

Thanks for the library, I somehow couldn't easily get the qmc5883l working myself!